### PR TITLE
Fix markdown headings and DESCRIPTION URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,8 @@ Authors@R: c(
   LL = person("Libby", "Liggins", email = "L.Liggins@massey.ac.nz", role = c("aut")),
   CP = person("Christian", "Parobek", email = "christian.parobek@gmail.com", role = c("aut")),
   AS = person("Allan", "Strand", email = "stranda@gmail.com", role = c("aut", "cre")))
-URL: https:://github.com/christianparobek/skelesim
-BugReports: https://github.com/christianparobek/skelesim/issues
+URL: https://github.com/christianparobek/skeleSim
+BugReports: https://github.com/christianparobek/skeleSim/issues
 Description: A shiny interface and supporting tools to guide users in choosing
     appropriate simulations, setting parameters, calculating summary genetic
     statistics, and organizing data output, all within the R environment. In

--- a/vignettes/Forecasting.Rmd
+++ b/vignettes/Forecasting.Rmd
@@ -12,7 +12,7 @@ vignette: >
 This vignette will create a forecast of possible outcomes for a population of interest, such as a rare species.   
 These are examples of null model construction using simulators, to help showcase possible uses of SkeleSim.
 
-##Overall instructions: getting started    
+## Overall instructions: getting started    
 
 launch the skeleSim GUI
 ```{r,echo=T,eval=FALSE}

--- a/vignettes/Forecasting.html
+++ b/vignettes/Forecasting.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="S Hoban" />
 
-<meta name="date" content="2016-09-12" />
+<meta name="date" content="2017-11-22" />
 
 <title>Running a forecasting simulation in skeleSim</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Running a forecasting simulation in skeleSim</h1>
 <h4 class="author"><em>S Hoban</em></h4>
-<h4 class="date"><em>2016-09-12</em></h4>
+<h4 class="date"><em>2017-11-22</em></h4>
 
 
 
@@ -139,7 +139,7 @@ These are examples of null model construction using simulators, to help showcase
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -11,11 +11,11 @@ vignette: >
 
 This vignette focuses on getting everything together to get this package to run.
 
-##CRAN Dependencies
+## CRAN Dependencies
 
 There are several packages located on CRAN that skeleSim depends upon.  They all currently install automatically during the installation process.  
 
-##Non-CRAN dependencies
+## Non-CRAN dependencies
 
 Currently, skeleSim implements coalescent simulations in `fastsimcoal2` and forward-time in `rmetasim`. The `rmetasim` dependency is handled via normal package installation.
 
@@ -27,7 +27,7 @@ Helpful instructions for editing the PATH environmental variable for Windows can
 
 If the executable is in your path, skeleSimGUI() looks for it (and other versions if present) and allows you to select among versions on the "FastSimCoal params" tab.
 
-##Installing from github
+## Installing from github
 The most up to date version (new bugs and all) of skeleSim is always going to be on github.  This is also a place to ask specific questions about skeleSim.
 
 First install the great 'devtools' package. Then,

--- a/vignettes/Installing.html
+++ b/vignettes/Installing.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="A Strand" />
 
-<meta name="date" content="2016-09-07" />
+<meta name="date" content="2017-11-22" />
 
 <title>Installing skeleSim</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Installing skeleSim</h1>
 <h4 class="author"><em>A Strand</em></h4>
-<h4 class="date"><em>2016-09-07</em></h4>
+<h4 class="date"><em>2017-11-22</em></h4>
 
 
 
@@ -105,7 +105,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>

--- a/vignettes/SampleSize.Rmd
+++ b/vignettes/SampleSize.Rmd
@@ -13,7 +13,7 @@ This vignette will help plan the best sampling effort in terms of number of mark
 
 
 
-##Overall instructions: getting started    
+## Overall instructions: getting started    
 
 launch the skeleSim GUI
 ```{r,echo=T,eval=FALSE}

--- a/vignettes/SampleSize.html
+++ b/vignettes/SampleSize.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="S Hoban" />
 
-<meta name="date" content="2016-09-12" />
+<meta name="date" content="2017-11-22" />
 
 <title>Choosing Sample Size</title>
 
@@ -70,12 +70,11 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Choosing Sample Size</h1>
 <h4 class="author"><em>S Hoban</em></h4>
-<h4 class="date"><em>2016-09-12</em></h4>
+<h4 class="date"><em>2017-11-22</em></h4>
 
 
 
 <p>This vignette will help plan the best sampling effort in terms of number of markers or number of samples, for a planned population genetic study. <strong>The best sampling effort is one that ensures you detect the effect or process you are interested in.</strong></p>
-<p>(This is called power analysis- an introduction to this topic can be found at <a href="http://documents.software.dell.com/Statistics/Textbook/Power-Analysis">this website</a>).</p>
 <div id="overall-instructions-getting-started" class="section level2">
 <h2>Overall instructions: getting started</h2>
 <p>launch the skeleSim GUI</p>
@@ -114,7 +113,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>

--- a/vignettes/Simulating.Rmd
+++ b/vignettes/Simulating.Rmd
@@ -11,18 +11,18 @@ vignette: >
 
 This vignette focuses on what happens when you push the "Run Simulation" button on the Actions tab.
 
-##Setting up and running simulations are asynchronous activities
+## Setting up and running simulations are asynchronous activities
 
 Simulations, particularly forward-time simulations, are time consuming.  skeleSimGUI() was designed so that while a simulation is running, a user can edit the same simulation parameters to set up a new run, open or create a completely different simulation parameter set, or visualize the results of a previously run simulation.
 
-###Each simulation runs in its own independent R session
+### Each simulation runs in its own independent R session
 
 This asynchrony is achieved by spawning a new R process for each simulation.  In addition, skeleSimGUI() *does not wait for the newly spawned process to finish.*  While this prevents the interface from halting during simulations, it does require the user to look for output files in the "root simulation directory".
 
-###File inputs and outputs
+### File inputs and outputs
 The newly spawned R process executes in the "root simulation directory" specified on the Actions tab.  During a simulation, working files are written to a subdirectory specified on the general parameters tab.  Changing this subdirectory tab allows a user to launch as many simulations as their computer can accommodate and the different simulations will not write over each other's files.  The input, output, and R code that uses and produces them is saved to the "root simulation directory".
 
-####File names
+#### File names
 
 the filename prefix format for all skeleSim files produced during simulation has the following format:
 'title.date.hhmm.ms'  where 'title' is specified on the general configuration tab and the rest are calculated from the system clock.
@@ -52,10 +52,10 @@ The input file is an R binary format file that contains a skeleSim class object.
 #### output file
 The output file has the exact same structure as the input file.  Some slots that are NULL in a newly created input file have results in them, most importantly the slot "analysis.results" which contains 3 dimensional arrays that hold results of summary statistics calculations per simulation rep.
 
-##Using the output
+## Using the output
 The output file can be read into the skeleSimGUI() and the results can be visualized. Furthermore, this also reads simulation parameters into a skeleSimGUI() session where they can be altered and a new simulation run.
 
-##Running a simulation 'by hand'
+## Running a simulation 'by hand'
 Once skeleSimGUI() runs a simulation the relevant R script like the one above is available on disk.  All the user has to do is source it into an R session and the simulation will run again.
 
 ```{r,eval=FALSE}
@@ -71,7 +71,7 @@ ssClass <- runSim(ssClass) #run simulation.  now results are stored in ssClass@a
 ```
 
 
-##Troubleshooting
+## Troubleshooting
 Common problems include:
   
  1. **Not specifying the root simulation directory** Depending on the

--- a/vignettes/Simulating.html
+++ b/vignettes/Simulating.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="A Strand" />
 
-<meta name="date" content="2016-05-17" />
+<meta name="date" content="2017-11-22" />
 
 <title>Running simulations in skeleSim</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Running simulations in skeleSim</h1>
 <h4 class="author"><em>A Strand</em></h4>
-<h4 class="date"><em>2016-05-17</em></h4>
+<h4 class="date"><em>2017-11-22</em></h4>
 
 
 
@@ -145,7 +145,7 @@ ssClass &lt;-<span class="st"> </span><span class="kw">runSim</span>(ssClass) <s
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>


### PR DESCRIPTION
The headings in the vignettes were not being rendered properly because of a lack of space between the hash mark and the first character. Moreover, the DESCRIPTION URL had two colons, which rendered it invalid.